### PR TITLE
CI: add aggregate test gate for branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,19 @@ jobs:
 
       - name: Execute tests
         run: composer run test
+
+  # Aggregate gate: a single, stable check name for branch protection to require,
+  # so the ruleset never needs updating when the PHP/Laravel matrix changes.
+  tests-passed:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Confirm every matrix job succeeded
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more test matrix jobs did not succeed (result: ${{ needs.test.result }})."
+            exit 1
+          fi
+          echo "All test matrix jobs passed."

--- a/docs/plans/branch-protection-ruleset.md
+++ b/docs/plans/branch-protection-ruleset.md
@@ -7,6 +7,7 @@
 
 - 2026-05-14: Initial draft
 - 2026-05-14: Implemented — CI updated, ruleset applied, verified
+- 2026-07-01: Fixed stale required checks. When Laravel 12/13 support was added (commit `b081c9a`), the matrix job names gained an `L{laravel}` segment, so the four hard-coded required contexts (`P8.3 - prefer-lowest - ubuntu-latest`, …) no longer matched any job and blocked every PR. Replaced them with a single stable aggregate gate job **"All tests passed"** (`tests-passed` in `test.yml`, `needs: test`) plus the docs gate **"Verify generated docs are in sync"**. The ruleset now requires those two checks, which survive future matrix changes.
 
 ## Goal
 


### PR DESCRIPTION
## Problem

Branch protection on `main` requires four status checks by exact name:
`P8.3 - prefer-lowest - ubuntu-latest`, `P8.3 - prefer-stable - ubuntu-latest`, `P8.4 - prefer-lowest - ubuntu-latest`, `P8.4 - prefer-stable - ubuntu-latest`.

When Laravel 12/13 support was added (commit `b081c9a`), the matrix job names gained an `L{laravel}` segment (e.g. `P8.3 - L11.* - prefer-lowest - ubuntu-latest`). None of the required names match any job anymore, so those checks sit forever on "Expected — waiting for status to be reported" and **every PR is blocked**.

## Fix

Add a single aggregate gate job **`All tests passed`** (`tests-passed`, `needs: test`, `if: always()`) that fails unless every matrix job succeeded. The ruleset is updated (out-of-band, via API) to require just two stable checks:

- `All tests passed`
- `Verify generated docs are in sync`

These names don't change when the PHP/Laravel matrix grows, so this won't recur.

The branch-protection plan (`docs/plans/branch-protection-ruleset.md`) is updated to document the change.