### PR TITLE
Chore: replace aldemeery/onion with in-package Pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": "^8.3|^8.4|^8.5",
-        "aldemeery/onion": "^1.0",
         "illuminate/contracts": "*",
         "illuminate/support": "*",
         "nikic/php-parser": "^5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,75 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4e6a88162b5a4b25f74cc786b1374a7",
+    "content-hash": "1b63d7cec3ab25be358dc3d182357baa",
     "packages": [
-        {
-            "name": "aldemeery/onion",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/aldemeery/onion.git",
-                "reference": "e93eb8de18f64e271fef928ad77ca0037d3f13db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/aldemeery/onion/zipball/e93eb8de18f64e271fef928ad77ca0037d3f13db",
-                "reference": "e93eb8de18f64e271fef928ad77ca0037d3f13db",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.2"
-            },
-            "require-dev": {
-                "infection/infection": "^0.29.0",
-                "laravel/pint": "^1.16",
-                "laravel/sail": "^1.29",
-                "phpstan/phpstan": "^1.11",
-                "phpstan/phpstan-phpunit": "^1.4",
-                "phpunit/phpunit": "^11.1",
-                "squizlabs/php_codesniffer": "^3.10",
-                "symfony/var-dumper": "^7.0",
-                "thecodingmachine/phpstan-safe-rule": "^1.2"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
-                "psr-4": {
-                    "Aldemeery\\Onion\\": "src/",
-                    "Tests\\Aldemeery\\Onion\\": "tests/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Osama Aldemeery",
-                    "email": "aldemeery@gmail.com"
-                }
-            ],
-            "description": "A layering mechanism for PHP applications.",
-            "homepage": "https://github.com/aldemeery/onion",
-            "keywords": [
-                "compose",
-                "layer",
-                "layered",
-                "middleware",
-                "onion",
-                "pipeline",
-                "reduce",
-                "reducer",
-                "stack"
-            ],
-            "support": {
-                "issues": "https://github.com/aldemeery/onion/issues",
-                "source": "https://github.com/aldemeery/onion"
-            },
-            "time": "2024-10-26T00:30:42+00:00"
-        },
         {
             "name": "brick/math",
             "version": "0.18.0",

--- a/src/Domain/PhpParser/Models/MigrationCreatePropertyType.php
+++ b/src/Domain/PhpParser/Models/MigrationCreatePropertyType.php
@@ -4,7 +4,7 @@ namespace Albertoarena\LaravelEventSourcingGenerator\Domain\PhpParser\Models;
 
 use Albertoarena\LaravelEventSourcingGenerator\Domain\Blueprint\Concerns\HasBlueprintColumnType;
 use Albertoarena\LaravelEventSourcingGenerator\Domain\Blueprint\Contracts\BlueprintUnsupportedInterface;
-use Aldemeery\Onion\Onion;
+use Albertoarena\LaravelEventSourcingGenerator\Domain\Support\Pipeline;
 use Illuminate\Support\Str;
 
 class MigrationCreatePropertyType
@@ -46,27 +46,27 @@ class MigrationCreatePropertyType
 
     public function toBuiltInType(): string
     {
-        return (new Onion([
+        return (new Pipeline([
             fn ($type) => $this->columnTypeToBuiltInType($type),
             fn ($type) => Str::replaceFirst('?', '', $type),
-        ]))->peel($this->type);
+        ]))->process($this->type);
     }
 
     public function toNormalisedBuiltInType(): string
     {
-        return (new Onion([
+        return (new Pipeline([
             fn ($type) => $this->toBuiltInType(),
             fn ($type) => $this->normaliseCarbon($type),
-        ]))->peel($this->type);
+        ]))->process($this->type);
     }
 
     public function toProjection(): string
     {
-        return (new Onion([
+        return (new Pipeline([
             fn ($type) => $this->columnTypeToBuiltInType($type),
             fn ($type) => $this->carbonToBuiltInType($type),
             fn ($type) => Str::replaceFirst('?', '', $type),
-        ]))->peel($this->type);
+        ]))->process($this->type);
     }
 
     public function isCarbon(): bool

--- a/src/Domain/Stubs/StubReplacer.php
+++ b/src/Domain/Stubs/StubReplacer.php
@@ -6,12 +6,10 @@ use Albertoarena\LaravelEventSourcingGenerator\Domain\Blueprint\Concerns\HasBlue
 use Albertoarena\LaravelEventSourcingGenerator\Domain\Blueprint\Concerns\HasBlueprintFake;
 use Albertoarena\LaravelEventSourcingGenerator\Domain\Command\Models\CommandSettings;
 use Albertoarena\LaravelEventSourcingGenerator\Domain\PhpParser\Models\MigrationCreateProperty;
-use Aldemeery\Onion\Interfaces\Invokable;
+use Albertoarena\LaravelEventSourcingGenerator\Domain\Support\Pipeline;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-
-use function Aldemeery\Onion\onion;
 
 class StubReplacer
 {
@@ -418,7 +416,7 @@ class StubReplacer
         return $this;
     }
 
-    public function queue(array|Closure|Invokable $layers): self
+    public function queue(array $layers): self
     {
         $this->queue = array_merge($this->queue, $layers);
 
@@ -427,10 +425,10 @@ class StubReplacer
 
     public function run(&$stub): void
     {
-        $stub = onion([
+        $stub = (new Pipeline([
             fn ($stub) => $this->replace($stub),
             ...$this->queue,
             fn ($stub) => $this->afterReplacements($stub),
-        ])->peel($stub);
+        ]))->process($stub);
     }
 }

--- a/src/Domain/Support/Pipeline.php
+++ b/src/Domain/Support/Pipeline.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Albertoarena\LaravelEventSourcingGenerator\Domain\Support;
+
+/**
+ * A minimal left-to-right value pipeline: process($x) runs $x through each
+ * layer in order, passing the result of one layer to the next.
+ *
+ * Replaces the (abandoned) aldemeery/onion dependency, of which only this
+ * simple pipe behaviour was ever used.
+ */
+final class Pipeline
+{
+    /** @param  list<callable>  $layers */
+    public function __construct(private array $layers = []) {}
+
+    public function process(mixed $passable): mixed
+    {
+        return array_reduce(
+            $this->layers,
+            fn (mixed $carry, callable $layer): mixed => $layer($carry),
+            $passable,
+        );
+    }
+}

--- a/tests/Unit/Domain/Support/PipelineTest.php
+++ b/tests/Unit/Domain/Support/PipelineTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Domain\Support;
+
+use Albertoarena\LaravelEventSourcingGenerator\Domain\Support\Pipeline;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PipelineTest extends TestCase
+{
+    #[Test]
+    public function it_returns_the_passable_unchanged_for_an_empty_pipeline()
+    {
+        $this->assertSame('abc', (new Pipeline)->process('abc'));
+        $this->assertSame(42, (new Pipeline([]))->process(42));
+    }
+
+    #[Test]
+    public function it_applies_a_single_layer()
+    {
+        $result = (new Pipeline([
+            fn (int $n): int => $n + 1,
+        ]))->process(1);
+
+        $this->assertSame(2, $result);
+    }
+
+    #[Test]
+    public function it_applies_layers_left_to_right()
+    {
+        // 'a' -> append 'b' -> 'ab' -> uppercase -> 'AB'.
+        // Right-to-left would yield 'Ab', so this pins the order.
+        $result = (new Pipeline([
+            fn (string $s): string => $s.'b',
+            fn (string $s): string => strtoupper($s),
+        ]))->process('a');
+
+        $this->assertSame('AB', $result);
+    }
+
+    #[Test]
+    public function it_accepts_any_callable_not_only_closures()
+    {
+        $invokable = new class
+        {
+            public function __invoke(string $s): string
+            {
+                return $s.'!';
+            }
+        };
+
+        $result = (new Pipeline([
+            'strtoupper',   // string callable
+            $invokable,     // invokable object
+        ]))->process('hi');
+
+        $this->assertSame('HI!', $result);
+    }
+}


### PR DESCRIPTION
Implements `docs/plans/2026-07-01-replace-onion-dependency.md`. Removes the unmaintained runtime dependency `aldemeery/onion`.

## Why
`aldemeery/onion` is a `require` (runtime) dependency, last released 2024-10, and only its **simple left-to-right pipe** (`peel()`) was ever used — no middleware `$next`, exception handling, `addIf`/`addUnless`, or custom `Invokable` objects.

## What
- **New:** `src/Domain/Support/Pipeline.php` — a ~10-line final class: array constructor + `process()` (an `array_reduce`), semantically identical to the Onion usage.
- **Migrated 4 call sites:** `MigrationCreatePropertyType` (3×) and `StubReplacer::run()`; `StubReplacer::queue()` retyped `array|Closure|Invokable` → `array`.
- **Dropped** `aldemeery/onion` from `composer.json` + lock.

## TDD
Built test-first: `tests/Unit/Domain/Support/PipelineTest.php` (empty-pipeline identity, single layer, left-to-right order, arbitrary `callable`) — RED → implement → GREEN.

## Verification
- `composer test` — **83 tests** (79 existing + 4 new), all green → behaviour parity across every call site.
- `composer static` (PHPStan lvl 5) + `composer check` (Pint) green.
- No `onion`/`Onion`/`aldemeery`/`Invokable` references remain.