### PR TITLE
Chore(deps): Bump league/commonmark from 2.8.2 to 2.10.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1451,16 +1451,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -1482,8 +1482,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -1497,7 +1497,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -1554,7 +1554,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
Bumps `league/commonmark` from 2.8.2 to 2.10.0 in `composer.lock`, clearing six open Dependabot alerts (#43–#48).

## Advisories resolved

| Alert | Severity | Summary |
|---|---|---|
| #48 | high | Quadratic-time denial of service when parsing crafted Markdown |
| #47 | high | Denial of service via duplicate footnote definitions |
| #46 | high | Denial of service via adjacent inline attribute blocks |
| #44 | high | Denial of service via colliding heading slugs |
| #45 | medium | `AttributesExtension` href/src unsafe-link filter bypass via embedded control bytes |
| #43 | medium | Denial of service via deeply nested XML output |

All six are fixed in 2.9.0; this lands 2.10.0.

## Scope

Dev-only dependency, reached via `orchestra/testbench` → `laravel/framework` (`league/commonmark ^2.8.1`). It is not part of the published package's `require` block, so consumers were never exposed — `composer.lock` only affects local development and CI.

`composer.json` is unchanged: the existing constraint already permitted the bump, so the diff is 8 lines of lock file and no other package moved.

## Verification

Run locally on this branch:

- `composer test` — OK (83 tests, 14030 assertions)
- `composer check` (Pint) — passed
- `composer static` (PHPStan / Larastan) — no errors
- `composer docs:check` — documentation up to date
- `composer audit` — no security vulnerability advisories found