### PR TITLE
Chore(deps): Bump nanoid from 3.3.17 to 3.3.18 in /website

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5504,9 +5504,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes Dependabot alert #50 — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high, CVSS 5.9): nanoid's custom generators can loop indefinitely when size is zero.

`nanoid` is only a transitive dependency (`postcss` requires `^3.3.16`), so 3.3.18 satisfies the existing constraint and this is a lockfile-only change — three lines, no manifest edit and no other package moves.

The alert has been open since 17 Aug with no Dependabot PR, even though automated security fixes are enabled, so it needed doing by hand.

### Verification

Ran against this branch (Node 24.11.1 / npm 11.6.2, matching the lockfile's own npm generation):

- `npm ci` — clean, `found 0 vulnerabilities`
- installed tree resolves `nanoid@3.3.18` alongside `astro@7.2.6` from #45
- `npm run build` — 12 pages built, Pagefind index and sitemap generated

Note for anyone rerunning this locally: `npm update nanoid` under npm 10.x strips the `libc` fields from the linux optional deps (88 lines of unrelated churn), so the entry was edited by hand instead.