### PR TITLE
Docs: add Why PHP badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/albertoarena/laravel-event-sourcing-generator.svg?style=flat-square)](https://packagist.org/packages/albertoarena/laravel-event-sourcing-generator)
 [![License](https://img.shields.io/badge/license-MIT-red.svg?style=flat-square)](LICENSE.md)
 ![Code Size](https://img.shields.io/github/languages/code-size/albertoarena/laravel-event-sourcing-generator)
+[![Why PHP](https://img.shields.io/badge/Why_PHP-in_2026-7A86E8?style=flat-square&labelColor=18181b)](https://whyphp.dev)
 
 Laravel event sourcing generator scaffolds complete domain structures for [Spatie's Laravel Event Sourcing](https://github.com/spatie/laravel-event-sourcing), providing a single Artisan command to generate events, projections, projectors, aggregates, reactors, actions, DTOs, notifications, and PHPUnit tests — optionally straight from an existing migration.
 


### PR DESCRIPTION
Adds the community badge from [whyphp.dev/#badge](https://whyphp.dev/#badge) to the README badge row, linking to https://whyphp.dev.

```markdown
[![Why PHP](https://img.shields.io/badge/Why_PHP-in_2026-7A86E8?style=flat-square&labelColor=18181b)](https://whyphp.dev)
```

Taken verbatim from the site's snippet. The site offers "flat-square" and "flat" styles — flat-square matches the Documentation, Packagist, and License badges already in the row, so the badge sits consistently with its neighbours.

Placed last, after Code Size, so the project's own signals (coverage, docs, version, downloads, license) stay first.

### Note on longevity

The badge text is year-stamped — `Why_PHP-in_2026` — so it will read "in 2026" until the URL is updated by hand. Worth a look each January, or swapping to the undated variant if the site offers one later.

### Verification

- Badge image URL returns `200`, `image/svg+xml`, 569 bytes
- https://whyphp.dev returns `200`
- `composer docs:check` passes — the badge row is hand-written, not part of the code-derived block